### PR TITLE
Updated risk indicator bot to use new feed with all monitorings

### DIFF
--- a/openprocurement/bot/risk_indicators/bridge.py
+++ b/openprocurement/bot/risk_indicators/bridge.py
@@ -83,7 +83,7 @@ class RiskIndicatorBridge(object):
         return self.request(url)
 
     def get_tender_monitoring_list(self, tender_id):
-        url = "{}tenders/{}/monitorings".format(self.monitors_host, tender_id)
+        url = "{}tenders/{}/monitorings?mode=draft".format(self.monitors_host, tender_id)
         response = self.request(url)
         return response["data"]
 


### PR DESCRIPTION
Due to recent updates in monitoring API, monitorings in draft status were
no longer listed in the API. We need to use a separate view feed to get
list with draft monitorings included